### PR TITLE
Issue #9: gnupg type autorequires its user

### DIFF
--- a/lib/puppet/type/gnupg_key.rb
+++ b/lib/puppet/type/gnupg_key.rb
@@ -8,6 +8,10 @@ Puppet::Type.newtype(:gnupg_key) do
     ["gnupg", "gnupg2"]
   end
 
+  autorequire(:user) do
+    self[:user]
+  end
+
   KEY_SOURCES = [:key_source, :key_server, :key_content]
 
   KEY_CONTENT_REGEXES = {


### PR DESCRIPTION
Details in #9 

Have run the following to check if I have introduced regressions:
* `rake test`
* `rake beaker`

All tests appear to pass.