### PR TITLE
Remove the ensure value validation

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -25,9 +25,5 @@ class gnupg(
   $package_name   = $gnupg::params::package_name,
 ) inherits gnupg::params {
 
-  if !($package_ensure in ['present', 'absent']) {
-    fail('ensure must be either present or absent')
-  }
-
   class {'::gnupg::install': }
 }


### PR DESCRIPTION
It is wrong, ensure can be also 'latest', or a package version. There is no
real need to validate the input, as none other module does it.